### PR TITLE
feat(`miniImagenet`) Refactor data directory and add `miniImageNet`

### DIFF
--- a/gwnmo/data/__init__.py
+++ b/gwnmo/data/__init__.py
@@ -2,4 +2,5 @@ from .cifar10 import setup_CIFAR10
 from .fmnist import setup_FMNIST
 from .mnist import setup_MNIST
 from .svhn import setup_SVHN
-from .fs_omniglot import experimental_setup_FS_Omniglot
+from .fewshot import experimental_setup_FS_Omniglot
+from .fewshot import experimental_setup_FS_MiniImagenet

--- a/gwnmo/data/fewshot/__init__.py
+++ b/gwnmo/data/fewshot/__init__.py
@@ -1,0 +1,2 @@
+from .fs_omniglot import experimental_setup_FS_Omniglot
+from .fs_miniimagenet import experimental_setup_FS_MiniImagenet

--- a/gwnmo/data/fewshot/fs_miniimagenet.py
+++ b/gwnmo/data/fewshot/fs_miniimagenet.py
@@ -1,0 +1,179 @@
+from torchvision.datasets import VisionDataset
+import os
+from typing import Callable, Optional, Union, Literal, Any
+from os.path import join
+from .utils import SubDataset
+from torch.utils.data import DataLoader
+import numpy as np
+import json
+import requests
+import re
+from os import listdir
+import random
+from .utils import DataManager
+import torchvision.transforms as transforms
+from torchvision.models import ResNet18_Weights
+
+# Since access to miniImagenet is restricted we use dataset from our server.
+# This directory should not be modified so we define another SAVE_DIR path to store {train|val|test}.json files there.
+DATASET_DIR = os.getenv('DATASET_DIR')
+SAVE_DIR = os.getenv('SAVE_DIR') # This should be treated as root of dataset
+
+class FSMiniImagenet(VisionDataset):
+    folder = 'miniImagenet-fewshot'
+
+    train_url = 'https://raw.githubusercontent.com/twitter/meta-learning-lstm/master/data/miniImagenet/train.csv'
+    val_url = 'https://raw.githubusercontent.com/twitter/meta-learning-lstm/master/data/miniImagenet/val.csv'
+    test_url = 'https://raw.githubusercontent.com/twitter/meta-learning-lstm/master/data/miniImagenet/test.csv'
+
+    def __init__(self, 
+                 root: str,
+                 type: Union[Literal['base'], Literal['val'], Literal['novel']] = 'base',
+                 batch_size: int = None,
+                 transform: Optional[Callable] = None,
+                 target_transform: Optional[Callable] = None,
+                 download = True,
+                 ):
+        super().__init__(os.path.join(root, self.folder), transform=transform, target_transform=target_transform)
+
+        # `download` is a bit misused name here. In fact, this part of code prepares {train|val|test}.json files and downloads only csv files.
+        # Access to miniImageNet is restricted so we do not expose download here.
+        if download:
+            self._save_csv_files()
+            self._write_miniImagenet_filelist(cross=False)
+            self._write_miniImagenet_filelist(cross=True)
+
+        self.type = type
+        assert batch_size is not None
+        self.batch_size = batch_size
+
+        # setup dataset
+        self.data_file = join(self.root, self.type) + '.json'
+
+        with open(self.data_file, 'r') as f:
+            self.meta = json.load(f)
+ 
+        self.cl_list = np.unique(self.meta['image_labels']).tolist()
+        self.sub_meta = {}
+
+        for cl in self.cl_list:
+            self.sub_meta[cl] = []
+
+        for x,y in zip(self.meta['image_names'],self.meta['image_labels']):
+            self.sub_meta[y].append(x)
+
+        self.sub_dataloader = [] 
+        sub_data_loader_params = dict(
+            batch_size = batch_size,
+            shuffle = True,
+            pin_memory = False
+        )
+
+        for cl in self.cl_list:
+            sub_dataset = SubDataset(self.sub_meta[cl], cl, transform = transform)
+            self.sub_dataloader.append(DataLoader(sub_dataset, **sub_data_loader_params))
+
+    def _save_csv_files(self):
+        text_data_dict = {
+            'train.csv': requests.get(self.train_url),
+            'test.csv': requests.get(self.test_url),
+            'val.csv': requests.get(self.val_url),
+        }
+
+        for filename in text_data_dict.keys():
+            with open(os.path.join(self.root, filename), 'w') as f:
+                f.write(text_data_dict[filename].text)
+    
+    def _write_miniImagenet_filelist(self, cross=False):
+        datasets = {
+            'base': 'train',
+            'val': 'val',
+            'novel': 'test',
+        }
+
+        filelists = {
+            'base': {},
+            'val': {},
+            'novel': {},
+        }
+
+        flattened_filelists = {
+            'base': [],
+            'val': [],
+            'novel': [], 
+        }
+
+        flattened_labels = {
+            'base': [],
+            'val': [],
+            'novel': [],  
+        }
+
+        directory_list = []
+
+        for dataset in datasets.keys():
+            with open(join(self.root,datasets[dataset]) + '.csv', 'r') as lines:
+                for i, line in enumerate(lines):
+                    if i == 0:
+                        continue
+                    fid, _ , label = re.split(',|\.', line)
+                    label = label.replace('\n','')
+
+                    if not label in filelists[dataset]:
+                        directory_list.append(label)
+                        filelists[dataset][label] = []
+                        filenames = listdir(join(DATASET_DIR, label))
+                        filenames_numbers = [int(re.split('_|\.', fname)[1]) for fname in filenames]
+                        sorted_filenames = list(zip( *sorted(  zip(filenames, filenames_numbers), key = lambda file: file[1] )))[0]
+
+                    fid = int(fid[-5:])-1
+                    fname = join(DATASET_DIR,label, sorted_filenames[fid])
+                    filelists[dataset][label].append(fname)
+
+            for cl, (key, filelist) in enumerate(filelists[dataset].items()):
+                random.shuffle(filelists)
+                flattened_filelists += filelists
+                flattened_labels += np.repeat(cl, len(filelist)).tolist() 
+
+        if cross:
+            with open(join(self.root,'all.json'), 'w') as f:
+                json.dump({
+                    'label_names': directory_list,
+                    'image_names': [image for _, filesList in flattened_filelists.items() for image in filesList],
+                    'image_labels': [label for _, labelsList in flattened_labels.items() for label in labelsList],
+                }, f) 
+        else:
+            for dataset in datasets.keys():
+                with open(join(self.root,dataset) + '.json', 'w') as f:
+                    json.dump({
+                    'label_names': directory_list,
+                    'image_names': flattened_filelists[dataset],
+                    'image_labels': flattened_labels[dataset],
+                }, f)
+                    
+# tasks here is equivalent of episodes
+def experimental_setup_FS_MiniImagenet(device, ways, shots, query, tasks):
+    image_size = 224
+    
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Lambda(lambda x: x.repeat(3, 1, 1)),
+        ResNet18_Weights.DEFAULT.transforms(antialias=True) 
+    ]) 
+    
+    miniimagenet_data_manager = DataManager(
+        image_size=image_size, 
+        n_way=ways, 
+        n_support=shots, 
+        n_query=query, 
+        n_episode=tasks, 
+        download=True, 
+        transform=transform, 
+        root=SAVE_DIR,
+        dataset_class=FSMiniImagenet,
+    )
+
+    train_loader = miniimagenet_data_manager.get_data_loader(type='base')
+    test_loader = miniimagenet_data_manager.get_data_loader(type='val')
+    
+    return train_loader, test_loader

--- a/gwnmo/data/fewshot/utils.py
+++ b/gwnmo/data/fewshot/utils.py
@@ -1,0 +1,58 @@
+import os
+from PIL import Image
+from torch.utils.data import DataLoader
+import torchvision.transforms as transforms
+import torch
+from typing import Any
+
+IDENTITY = lambda x:x
+
+class SubDataset:
+    def __init__(self, sub_meta, cl, transform=transforms.ToTensor(), target_transform=IDENTITY):
+        self.sub_meta = sub_meta
+        self.cl = cl 
+        self.transform = transform
+        self.target_transform = target_transform
+
+    def __getitem__(self,i):
+        image_path = os.path.join( self.sub_meta[i])
+        img = Image.open(image_path, mode="r").convert("L")
+        img = self.transform(img)
+        target = self.target_transform(self.cl)
+        return img, target
+
+    def __len__(self):
+        return len(self.sub_meta)
+
+class EpisodicBatchSampler(object):
+    def __init__(self, n_classes, n_way, n_episodes):
+        self.n_classes = n_classes
+        self.n_way = n_way
+        self.n_episodes = n_episodes
+
+    def __len__(self):
+        return self.n_episodes
+
+    def __iter__(self):
+        for i in range(self.n_episodes):
+            yield torch.randperm(self.n_classes)[:self.n_way]
+
+class DataManager:
+    def __init__(self, image_size: int, n_way: int, n_support: int, n_query: int, transform: Any, root: str, n_episode = 100, download = True, dataset_class = None):        
+        self.image_size = image_size
+        self.n_way = n_way
+        self.batch_size = n_support + n_query
+        self.n_episode = n_episode
+        self.transform = transform 
+        self.download = download
+        self.root = root
+        self.dataset_class = dataset_class
+
+    def get_data_loader(self, type): #parameters that would change on train/val set
+        dataset = self.dataset_class(root=self.root, download=self.download, type=type, transform=self.transform, batch_size=self.batch_size)
+        sampler = EpisodicBatchSampler(len(dataset), self.n_way, self.n_episode)  
+        self.download = False # download only once
+
+        data_loader_params = dict(batch_sampler = sampler, pin_memory=True)
+        data_loader = DataLoader(dataset, **data_loader_params)
+        return data_loader

--- a/gwnmo/utils.py
+++ b/gwnmo/utils.py
@@ -138,6 +138,7 @@ map2cmd = {
         "fmnist": setup_FMNIST,
         "cifar10": setup_CIFAR10,
         "svhn": setup_SVHN,
-        "omniglot": experimental_setup_FS_Omniglot
+        "omniglot": experimental_setup_FS_Omniglot,
+        "miniImagenet": experimental_setup_FS_MiniImagenet,
     }
 }


### PR DESCRIPTION
Changes:

1. In `data` directory there is a separate directory for handling few-shot datasets.
2. I removed part of the repeating code. Still we have some repeating logic especially for extracting dataset metadata to `*.json` files. I want to take care of it in incoming PRs. I would like to introduce `FSDataseBase` to share common logic there.
3. I want to modify `map2cmd` functions to make them more flexible. Especially pick transformations based on feature extractor.

5. We need to handle cross scenario. At the moment it is supported by the Dataset classes but we don't have possibility to trigger this.

6. Access to `miniImagenet` is restricted so the code is adjusted to work on server. This is why there are two environment variables `DATASET_DIR` and `SAVE_DIR` for dataset and its metadata respectively.

7. Omniglot still can be downloaded

I think it's worth to introduce `.env` file for loading environment variables.
Then we can create separate environment variables for different datasets and load it automatically. `.env` can be included in `.gitignore` so anyone can customise it.

This means that instead of `DATASET_DIR` we would have `OMNIGLOT_DATASET_DIR` and `MINI_IMAGENET_DATASET_DIR` etc.